### PR TITLE
Fix memory leak in (*nvgPathCache).allocVertexes()

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -107,9 +107,13 @@ type nvgPathCache struct {
 }
 
 func (c *nvgPathCache) allocVertexes(n int) []nvgVertex {
-	offset := len(c.vertexes)
-	c.vertexes = append(c.vertexes, make([]nvgVertex, n)...)
-	return c.vertexes[offset:]
+	if n > len(c.vertexes) {
+		// Round up to prevent allocations when things change just slightly.
+		n := (n + 0xff) & ^0xff
+		c.vertexes = append(c.vertexes, make([]nvgVertex, n-len(c.vertexes))...)
+	}
+
+	return c.vertexes
 }
 
 func (c *nvgPathCache) clearPathCache() {


### PR DESCRIPTION
Hi, this is a really awesome project. Thanks for porting nanovg to Go. :)

When I tried the sample code my laptop run out of memory and started swapping. I found the leak with the profiler and ported the code from [memononen/nanovg/nanovg.c:1111](https://github.com/memononen/nanovg/blob/master/src/nanovg.c#L1111) (nvg__allocTempVerts).

Memory usage is stable and the sample code still works.
