### PR TITLE
truetype.go: fix index out of range panic

### DIFF
--- a/fontstashmini/truetype/truetype.go
+++ b/fontstashmini/truetype/truetype.go
@@ -963,6 +963,9 @@ func u32(b []byte, i int) uint32 {
 
 // u16 returns the big-endian uint16 at b[i:].
 func u16(b []byte, i int) uint16 {
+	if i >= len(b)-2 {
+		return uint16(0)
+	}
 	return uint16(b[i])<<8 | uint16(b[i+1])
 }
 


### PR DESCRIPTION
I was getting the following panic when certain corrupt characters were rendered:

```
panic: runtime error: index out of range

goroutine 1 [running, locked to thread]:
github.com/shibukawa/nanovgo/fontstashmini/truetype.(*FontInfo).GetGlyphHMetrics(0xc420052150, 0x10194, 0xf, 0x200)
	/Users/alex/src/github.com/shibukawa/nanovgo/fontstashmini/truetype/truetype.go:72 +0x12d
github.com/shibukawa/nanovgo/fontstashmini.(*Font).buildGlyphBitmap(0xc42006a240, 0x10194, 0x3c5a5f59, 0x4346580, 0x100, 0x4b, 0xd, 0xf, 0x200)
	/Users/alex/src/github.com/shibukawa/nanovgo/fontstashmini/fontstash_mini.go:618 +0x3c
github.com/shibukawa/nanovgo/fontstashmini.(*FontStash).getGlyph(0xc4200f00e0, 0xc42006a240, 0xfffd, 0x168, 0x0, 0x4526e9a545936000)
	/Users/alex/src/github.com/shibukawa/nanovgo/fontstashmini/fontstash_mini.go:451 +0x1b5
github.com/shibukawa/nanovgo/fontstashmini.(*TextIterator).Next(0xc4203e0700, 0x0, 0x0, 0x0, 0x0, 0xc4203e0701)
	/Users/alex/src/github.com/shibukawa/nanovgo/fontstashmini/fontstash_mini.go:376 +0xd5
github.com/shibukawa/nanovgo.(*Context).TextRune(0xc42000a700, 0x44a640004503e000, 0xc42009ee10, 0x21, 0x24, 0x24)
	/Users/alex/src/github.com/shibukawa/nanovgo/nanovgo.go:893 +0x381
github.com/shibukawa/nanovgo.(*Context).Text(0xc42000a700, 0x44a640004503e000, 0xc4200c60a2, 0x32, 0x459c6000)
	/Users/alex/src/github.com/shibukawa/nanovgo/nanovgo.go:867 +0x86
```

It turned out the `u16()` function was not checking array bounds.